### PR TITLE
Feature/color fixes

### DIFF
--- a/src/components/editors/WorldEditor.js
+++ b/src/components/editors/WorldEditor.js
@@ -86,14 +86,11 @@ class WorldEditor extends Component {
 
             <ToggleableCheckBoxField
               label={l10n("FIELD_EXPORT_CUSTOM_COLORS")}
-              open={!!project.CustomColorsEnabled || project.CustomColorsEnabled}
-              onToggle={this.onEditProject("CustomColorsEnabled")}
+              open={settings.customColorsEnabled}
+              onToggle={this.onEditSetting("customColorsEnabled")}
             >
-              
               <CustomPalettePicker />
-
             </ToggleableCheckBoxField>
-
           </div>
         </SidebarColumn>
 

--- a/src/components/forms/CustomPalettePicker.js
+++ b/src/components/forms/CustomPalettePicker.js
@@ -142,20 +142,24 @@ class CustomPalettePicker extends Component {
   }
 
   colorChange = e => {
-    if (e.target.id == "colorR")
+    const min = 0;
+    const max = 31;
+    const value = Math.max(min, Math.min(max, e.currentTarget.value))
+    
+    if (e.target.id === "colorR")
     {
-      this.setState({currentR: e.target.value});
-      this.setCurrentColor(e.target.value, this.state.currentG, this.state.currentB);
+      this.setState({currentR: value || ""});
+      this.setCurrentColor(value, this.state.currentG, this.state.currentB);
     } 
-    else if (e.target.id == "colorG")
+    else if (e.target.id === "colorG")
     {
-      this.setState({currentG: e.target.value});
-      this.setCurrentColor(this.state.currentR, e.target.value, this.state.currentB);
+      this.setState({currentG: value || ""});
+      this.setCurrentColor(this.state.currentR, value, this.state.currentB);
     }
-    else if (e.target.id == "colorB")
+    else if (e.target.id === "colorB")
     {
-      this.setState({currentB: e.target.value});
-      this.setCurrentColor(this.state.currentR, this.state.currentG, e.target.value);
+      this.setState({currentB: value || ""});
+      this.setCurrentColor(this.state.currentR, this.state.currentG, value);
     }
   }
 

--- a/src/components/forms/CustomPalettePicker.js
+++ b/src/components/forms/CustomPalettePicker.js
@@ -12,26 +12,20 @@ class CustomPalettePicker extends Component {
     super(props);
 
     const { project } = this.props;
+    const { settings } = project;
 
     this.state = {
       selectedPalette: -1,
       currentR: 0,
       currentG: 0,
       currentB: 0,
-      whiteHex: project.CustomColors_White || "E0F8D0",
-      lightGreenHex: project.CustomColors_LightGreen || "88C070",
-      darkGreenHex: project.CustomColors_DarkGreen || "306850",
-      blackHex: project.CustomColors_Black || "081820",
+      whiteHex: settings.customColorsWhite || "E0F8D0",
+      lightHex: settings.customColorsLight || "88C070",
+      darkHex: settings.customColorsDark || "306850",
+      blackHex: settings.customColorsBlack || "081820",
       currentCustomHex: ""
     };
   }
-
-  onEditProject = key => e => {
-    const { editProject } = this.props;
-    editProject({
-      [key]: castEventValue(e)
-    });
-  };
 
   paletteSelect = e => {    
     if (e.target.id == "customColor_0")
@@ -55,7 +49,7 @@ class CustomPalettePicker extends Component {
       else
       {
         this.setState({selectedPalette: 1});
-        this.applyHexToState(this.state.lightGreenHex);
+        this.applyHexToState(this.state.lightHex);
       }
     }
     else if (e.target.id == "customColor_2")
@@ -67,7 +61,7 @@ class CustomPalettePicker extends Component {
       else 
       {
         this.setState({selectedPalette: 2});
-        this.applyHexToState(this.state.darkGreenHex);
+        this.applyHexToState(this.state.darkHex);
       }
     }
     else if (e.target.id == "customColor_3")
@@ -115,7 +109,7 @@ class CustomPalettePicker extends Component {
   }
 
   setCurrentColor(r, g, b) {
-    const { editProject } = this.props;
+    const { editProjectSettings } = this.props;
 
     const hexString = this.decimalToHexString(r * 8) + 
                       this.decimalToHexString(g * 8) + 
@@ -124,22 +118,22 @@ class CustomPalettePicker extends Component {
     if (this.state.selectedPalette == 0)
     {    
       this.setState({ whiteHex: hexString });
-      editProject({ CustomColors_White: hexString });
+      editProjectSettings({ customColorsWhite: hexString });
     } 
     else if (this.state.selectedPalette == 1)
     {
-      this.setState({ lightGreenHex: hexString });
-      editProject({ CustomColors_LightGreen: hexString });
+      this.setState({ lightHex: hexString });
+      editProjectSettings({ customColorsLight: hexString });
     }
     else if (this.state.selectedPalette == 2)
     {
-      this.setState({ darkGreenHex: hexString });
-      editProject({ CustomColors_DarkGreen: hexString });
+      this.setState({ darkHex: hexString });
+      editProjectSettings({ customColorsDark: hexString });
     }
     else if (this.state.selectedPalette == 3)
     {
       this.setState({ blackHex: hexString });
-      editProject({ CustomColors_Black: hexString });
+      editProjectSettings({ customColorsBlack: hexString });
     }
   }
 
@@ -222,13 +216,13 @@ class CustomPalettePicker extends Component {
           </label>
           <label htmlFor="customColor_1" title={l10n('FIELD_COLOR2_NAME')}>
             <input id="customColor_1" type="checkbox" onChange={this.paletteSelect.bind()} checked={this.state.selectedPalette == 1} />
-            <div className="CustomPalettePicker__Button CustomPalettePicker__Button--Middle" style={{backgroundImage: `linear-gradient(#86c06c 48.9%, var(--input-border-color) 49.5%, #${this.state.lightGreenHex} 50%)`}}>
+            <div className="CustomPalettePicker__Button CustomPalettePicker__Button--Middle" style={{backgroundImage: `linear-gradient(#86c06c 48.9%, var(--input-border-color) 49.5%, #${this.state.lightHex} 50%)`}}>
               &nbsp;
             </div>
           </label>
           <label htmlFor="customColor_2" title={l10n('FIELD_COLOR3_NAME')}>
             <input id="customColor_2" type="checkbox" onChange={this.paletteSelect.bind()} checked={this.state.selectedPalette == 2} />
-            <div className="CustomPalettePicker__Button CustomPalettePicker__Button--Middle" style={{backgroundImage: `linear-gradient(#306850 48.9%, var(--input-border-color) 49.5%, #${this.state.darkGreenHex} 50%)`}}>
+            <div className="CustomPalettePicker__Button CustomPalettePicker__Button--Middle" style={{backgroundImage: `linear-gradient(#306850 48.9%, var(--input-border-color) 49.5%, #${this.state.darkHex} 50%)`}}>
               &nbsp;
             </div>
           </label>
@@ -340,7 +334,7 @@ function mapStateToProps(state, props) {
 }
 
 const mapDispatchToProps = {
-  editProject: actions.editProject
+  editProjectSettings: actions.editProjectSettings
 };
 
 export default connect(

--- a/src/components/library/Forms.js
+++ b/src/components/library/Forms.js
@@ -117,41 +117,34 @@ ToggleableFormField.defaultProps = {
 };
 
 export class ToggleableCheckBoxField extends Component {
-  constructor() {
-    super();
-    this.state = {
-      open: false
-    };
-  }
-
-  toggleOpen = () => {
-    const { onToggle } = this.props;
-    onToggle(!this.state.open);
-
-    this.setState({ open: !this.state.open });
-  };
 
   componentWillMount () {
     this.id = `toggle_${Math.random().toString().replace(/0\./, '')}`;
   }
+
+  toggleOpen = () => {
+    const { onToggle, open } = this.props;
+    onToggle(!open);
+  };
 
   render() {
     const {
       halfWidth,
       label,
       children,
-      open: propsOpen
+      open
     } = this.props;
-    const { open: stateOpen } = this.state;
-    const open = stateOpen || propsOpen;
     return (
       <div
         className={cx("FormField", "FormField--Toggleable", {
           "FormField--HalfWidth": halfWidth
         })}
       >
-        <input type="checkbox" onChange={this.toggleOpen} checked={open} id={this.id} style={{width:16,opacity:100,float:"left",position:"static"}}/>
-        <label htmlFor={this.id}>{label}</label>
+        <label htmlFor={this.id}>
+          <input id={this.id} type="checkbox" onChange={this.toggleOpen} checked={open} />
+          <div className="FormCheckbox" />
+          {label}
+        </label>
         <div>
           {open && children}
         </div>
@@ -164,7 +157,8 @@ ToggleableCheckBoxField.propTypes = {
   halfWidth: PropTypes.bool,
   children: PropTypes.node,
   label: PropTypes.node,
-  open: PropTypes.bool
+  open: PropTypes.bool,
+  onToggle: PropTypes.func.isRequired
 };
 
 ToggleableCheckBoxField.defaultProps = {

--- a/src/lib/compiler/buildMakeBat.js
+++ b/src/lib/compiler/buildMakeBat.js
@@ -1,7 +1,7 @@
 import fs from "fs-extra";
 import Path from "path";
 
-export default async (buildRoot, customColorsEnabled, { CART_TYPE }) => {
+export default async (buildRoot, { CART_TYPE, customColorsEnabled }) => {
   const cmds = [];
   const buildFiles = [];
   const objFiles = [];

--- a/src/lib/compiler/buildMakeBat.js
+++ b/src/lib/compiler/buildMakeBat.js
@@ -52,7 +52,7 @@ export default async (buildRoot, customColorsEnabled, { CART_TYPE }) => {
     objFiles.push(objFile);
   }
 
-  if (customColorsEnabled == true) {
+  if (customColorsEnabled) {
     cmds.push(`${CC} ${CFLAGS} ${CGBFLAGS} -o build/rom/game.gb ${objFiles.join(" ")}`);
   } else {
     cmds.push(`${CC} ${CFLAGS} -o build/rom/game.gb ${objFiles.join(" ")}`);

--- a/src/lib/compiler/buildProject.js
+++ b/src/lib/compiler/buildProject.js
@@ -52,7 +52,7 @@ const buildProject = async (
     const sanitize = s => String(s || "").replace(/["<>]/g, "");
     const projectName = sanitize(data.name);
     const author = sanitize(data.author);
-    const customColor = data.CustomColorsEnabled ? "<body style='background-color:#" + data.CustomColors_Black + "'>" : "<body>";
+    const customColor = data.settings.customColorsEnabled ? "<body style='background-color:#" + data.settings.customColorsBlack + "'>" : "<body>";
     const html = (await fs.readFile(
       `${outputRoot}/build/web/index.html`,
       "utf8"

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -63,6 +63,7 @@ const makeBuild = ({
 } = {}) => {
   return new Promise(async (resolve, reject) => {
     const env = Object.create(process.env);
+    const { settings } = data;
 
     const buildToolsPath = `${buildToolsRoot}/${process.platform}-${
       process.arch
@@ -84,30 +85,30 @@ const makeBuild = ({
 
     env.PATH = [`${tmpBuildToolsPath}/gbdk/bin`, env.PATH].join(":");
     env.GBDKDIR = `${tmpBuildToolsPath}/gbdk/`;
-    env.CART_TYPE = parseInt(data.settings.cartType || "1B", 16);
+    env.CART_TYPE = parseInt(settings.cartType || "1B", 16);
 
     // Modify game.h to overide color palette
     let gameHeader = await fs.readFile(`${buildRoot}/include/game.h`, "utf8");
-    if(data.CustomColorsEnabled) {
+    if(settings.customColorsEnabled) {
       gameHeader = gameHeader
-        .replace(/RGB\(28, 31, 26\)/g, convertHexTo15BitRGB(data.CustomColors_White))
-        .replace(/RGB\(17, 24, 14\)/g, convertHexTo15BitRGB(data.CustomColors_LightGreen))
-        .replace(/RGB\(6, 13, 10\)/g, convertHexTo15BitRGB(data.CustomColors_DarkGreen))
-        .replace(/RGB\(1, 3, 4\)/g, convertHexTo15BitRGB(data.CustomColors_Black));
+        .replace(/RGB\(28, 31, 26\)/g, convertHexTo15BitRGB(settings.customColorsWhite))
+        .replace(/RGB\(17, 24, 14\)/g, convertHexTo15BitRGB(settings.customColorsLight))
+        .replace(/RGB\(6, 13, 10\)/g, convertHexTo15BitRGB(settings.customColorsDark))
+        .replace(/RGB\(1, 3, 4\)/g, convertHexTo15BitRGB(settings.customColorsBlack));
     } else {
       gameHeader = gameHeader.replace(/#define CUSTOM_COLORS/g, '');
     }
     await fs.writeFile(`${buildRoot}/include/game.h`, gameHeader, "utf8");
 
     // Remove GBC Rombyte Offset from Makefile (OSX/Linux) if custom colors not enabled
-    if (process.platform !== "win32" && !data.CustomColorsEnabled)
+    if (process.platform !== "win32" && !settings.customColorsEnabled)
     {
       let makeFile = await fs.readFile(`${buildRoot}/Makefile`, "utf8");
       makeFile = makeFile.replace("-Wl-yp0x143=0x80", "");
       await fs.writeFile(`${buildRoot}/Makefile`, makeFile, "utf8");
     }
 
-    const makeBat = await buildMakeBat(buildRoot, data.CustomColorsEnabled, { CART_TYPE: env.CART_TYPE });
+    const makeBat = await buildMakeBat(buildRoot, settings.customColorsEnabled, { CART_TYPE: env.CART_TYPE });
     await fs.writeFile(`${buildRoot}/make.bat`, makeBat);
 
     const command = process.platform === "win32" ? "make.bat" : "make";

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -86,6 +86,7 @@ const makeBuild = ({
     env.GBDKDIR = `${tmpBuildToolsPath}/gbdk/`;
     env.CART_TYPE = parseInt(data.settings.cartType || "1B", 16);
 
+    // Modify game.h to overide color palette
     let gameHeader = await fs.readFile(`${buildRoot}/include/game.h`, "utf8");
     if(data.CustomColorsEnabled) {
       gameHeader = gameHeader
@@ -98,12 +99,12 @@ const makeBuild = ({
     }
     await fs.writeFile(`${buildRoot}/include/game.h`, gameHeader, "utf8");
 
-    // Modify Linux / OSX makefile as needed
+    // Remove GBC Rombyte Offset from Makefile (OSX/Linux) if custom colors not enabled
     if (process.platform !== "win32" && !data.CustomColorsEnabled)
     {
-      let makeFile = await fs.readFile(`${buildRoot}/makefile`, "utf8");
+      let makeFile = await fs.readFile(`${buildRoot}/Makefile`, "utf8");
       makeFile = makeFile.replace("-Wl-yp0x143=0x80", "");
-      await fs.writeFile(`${buildRoot}/makefile`, makeFile, "utf8");
+      await fs.writeFile(`${buildRoot}/Makefile`, makeFile, "utf8");
     }
 
     const makeBat = await buildMakeBat(buildRoot, data.CustomColorsEnabled, { CART_TYPE: env.CART_TYPE });

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -108,7 +108,10 @@ const makeBuild = ({
       await fs.writeFile(`${buildRoot}/Makefile`, makeFile, "utf8");
     }
 
-    const makeBat = await buildMakeBat(buildRoot, settings.customColorsEnabled, { CART_TYPE: env.CART_TYPE });
+    const makeBat = await buildMakeBat(buildRoot, {
+      CART_TYPE: env.CART_TYPE,
+      customColorsEnabled: settings.customColorsEnabled
+    });
     await fs.writeFile(`${buildRoot}/make.bat`, makeBat);
 
     const command = process.platform === "win32" ? "make.bat" : "make";

--- a/src/lib/compiler/makeBuild.js
+++ b/src/lib/compiler/makeBuild.js
@@ -4,6 +4,7 @@ import fs from "fs-extra";
 import { buildToolsRoot } from "../../consts";
 import copy from "../helpers/fsCopy";
 import buildMakeBat from "./buildMakeBat";
+import { hexDec } from "../helpers/8bit";
 
 const HEADER_TITLE = 0x134;
 const HEADER_CHECKSUM = 0x14d;
@@ -22,15 +23,12 @@ const setROMTitle = async (filename, title) => {
   await fs.writeFile(filename, await patchROM(romData));
 };
 
-const hexToDecimal = (str) => {
-    return parseInt("0x" + str);
-}
-
-const convertHexTo15BitString = (hex) => {
-  return  Math.round(hexToDecimal(hex.substring(0,2)) / 8) + ', ' +
-          Math.round(hexToDecimal(hex.substring(2,4)) / 8) + ', ' +
-          Math.round(hexToDecimal(hex.substring(4)) / 8);
-}
+const convertHexTo15BitRGB = hex => {
+  const r = Math.floor(hexDec(hex.substring(0, 2)) * (32 / 256));
+  const g = Math.floor(hexDec(hex.substring(2, 4)) * (32 / 256));
+  const b = Math.max(1, Math.floor(hexDec(hex.substring(4, 6)) * (32 / 256)));
+  return `RGB(${r}, ${g}, ${b})`;
+};
 
 const patchROM = romData => {
   let checksum = 0;
@@ -93,10 +91,10 @@ const makeBuild = ({
       var result;
 
       if (data.CustomColorsEnabled) {
-        result =  filedata.replace(/28, 31, 26/g, convertHexTo15BitString(data.CustomColors_White))
-                          .replace(/17, 24, 14/g, convertHexTo15BitString(data.CustomColors_LightGreen))
-                          .replace(/6, 13, 10/g, convertHexTo15BitString(data.CustomColors_DarkGreen))
-                          .replace(/1, 3, 4/g, convertHexTo15BitString(data.CustomColors_Black));
+        result =  filedata.replace(/RGB\(28, 31, 26\)/g, convertHexTo15BitRGB(data.CustomColors_White))
+                          .replace(/RGB\(17, 24, 14\)/g, convertHexTo15BitRGB(data.CustomColors_LightGreen))
+                          .replace(/RGB\(6, 13, 10\)/g, convertHexTo15BitRGB(data.CustomColors_DarkGreen))
+                          .replace(/RGB\(1, 3, 4\)/g, convertHexTo15BitRGB(data.CustomColors_Black));
       } else {
         result =  filedata.replace(/#define CUSTOM_COLORS/g, '');
       }

--- a/src/lib/helpers/8bit.js
+++ b/src/lib/helpers/8bit.js
@@ -18,6 +18,8 @@ export const decHex16 = dec =>
     .padStart(4, "0")
     .toUpperCase()}`;
 
+export const hexDec = hex => parseInt(hex, 16);
+
 export const hi = longNum => wrap16Bit(longNum) >> 8;
 
 export const lo = longNum => wrap16Bit(longNum) % 256;

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -13,7 +13,11 @@ export default {
     settings: {
       showCollisions: true,
       showConnections: true,
-      sidebarWidth: 300
+      sidebarWidth: 300,
+      customColorsWhite: "E0F8D0",
+      customColorsLight: "88C070",
+      customColorsDark: "306850",
+      customColorsBlack: "081820"
     }
   },
   world: {},


### PR DESCRIPTION
Hi @fydo,

I've made a few changes to your build to get it ready to merge with the main gb-studio repo.
I've tried to split everything up into separate commits that are self contained so you can see what I've done but the gist of the changes are:

- Fixed an issue where for some reason the green channel wouldn't work if the blue channel was set to "0", this may have been macOS only but seems to be the reason I was seeing red rather than orange on my example project.
- Moved the data to be stored in the project settings part of the `.gbsproj` file rather than being stored at the root matching how cartridge type was being stored, also changed naming a little.
- Made the checkbox on ToggleableCheckBoxField match the style of the one used in other parts of the app and fixed an issue where if the checkbox was checked when you loaded the project it needed two clicks to disable
- When you changed the colors in game.h it was using fs.readFile with a callback but not waiting until the file was written before continuing, it's very unlikely to occur but this could potentially have allowed the project to be built before the file had finished saving. I was using the module [fs-extra](https://github.com/jprichardson/node-fs-extra) which turns fs calls without a callback into promises and since I'm also using `async/await` I've changed these to `await fs.readFile()` etc. 
- Added min/max checks on the red, green and blue fields when setting colors preventing numbers below 0 and above 31.